### PR TITLE
fix links of Japan WG

### DIFF
--- a/docs/OpenChain_WGs.md
+++ b/docs/OpenChain_WGs.md
@@ -27,8 +27,8 @@ This repository holds the official OpenChain Specification releases in English a
 </figure>
 
 ## OpenChain Project Japan Work Group(JWG)<br>
- - [ReadMe](https://openchain-project.github.io/OpenChain-JWG/)<br>
- - [Wiki](https://wiki.linuxfoundation.org/openchain/openchain-japanese-working-group)<br>
+ - [ReadMe](https://github.com/OpenChain-Project/OpenChain-JWG/blob/master/README.md)<br>
+ - [Wiki](https://openchain-project.github.io/OpenChain-JWG/)<br>
  - [GitHub Project](https://github.com/OpenChain-Project/OpenChain-JWG/)<br>
 
 ## OpenChain Project Korea Work Group(KWG)<br>


### PR DESCRIPTION
I wrote an email about these links on June 20th.
However, it seems to be difficult to convey my intention with the text, so I issued this pull request.

I do not know we can call github.io Wiki, but we use github.io like Wiki.